### PR TITLE
Update package.json dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,9 @@
     "url": "https://github.com/netzstrategen/eslint-config-netzstrategen.git"
   },
   "dependencies": {
-    "eslint-plugin-import": "^2.23.3"
-  },
-  "devDependencies": {
     "eslint": "^7.27.0",
-    "eslint-config-airbnb-base": "^14.2.1"
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-plugin-import": "^2.23.3"
   },
   "peerDependencies": {
     "eslint": ">=7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/eslint-config",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Netzstrategen eslint config",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "eslint-config-airbnb-base": "^14.2.1"
   },
   "peerDependencies": {
-    "eslint": ">7"
+    "eslint": ">=7"
   }
 }


### PR DESCRIPTION
This PR fixes a wrong peer dependency version. `>7` indicates a version greater than 7, so it would match for `8`,`9` etc. If instead we would use `>7.x` then it would install anyversion between >7 and <8.

See more https://classic.yarnpkg.com/en/docs/dependency-versions/

Additionally I moved the devDependencies to the regular dependencies as the index.js file is extending the airbnb config which MUST be installed when this package is included. Since devDeps are not installed of a package are not installed when this package is installed from another one (only regular deps) I moved it to ensure all necessary packages are available.